### PR TITLE
Fix 3rdparty example bugs

### DIFF
--- a/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/db_create.command
+++ b/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/db_create.command
@@ -3,5 +3,5 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker run -it --rm --name="db_create" -e DATABASE_URL='postgres://todoapp@postgres/todos' --network codeship-python-django-todoapp-v2_default codeship-python-django-todoapp-v2_web python manage.py migrate
+docker run -it --rm --name="db_create" -e DATABASE_URL='postgres://todoapp@postgres/todos' --network codeshippythondjangotodoappv2_default codeshippythondjangotodoappv2_web python manage.py migrate
 

--- a/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/docker-compose.slim.yml
+++ b/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/docker-compose.slim.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   web:
-    image: codeship-python-django-todoapp-v2_web.slim
+    image: codeshippythondjangotodoappv2_web.slim
     command: sh -c "sleep 7 && python manage.py migrate && gunicorn -b 0.0.0.0:8000 todosapp.wsgi:application"
     depends_on:
       - postgres
@@ -17,3 +17,4 @@ services:
     environment:
       POSTGRES_USER: todoapp
       POSTGRES_DB: todos
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/run_app_only_slim.command
+++ b/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/run_app_only_slim.command
@@ -3,7 +3,7 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker run -it --rm --name="django_todo_app" -p 8000:8000 -e "DATABASE_URL=postgres://todoapp@postgres/todos" --network codeship-python-django-todoapp-v2_default codeship-python-django-todoapp-v2_web.slim gunicorn -b 0.0.0.0:8000 todosapp.wsgi:application
+docker run -it --rm --name="django_todo_app" -p 8000:8000 -e "DATABASE_URL=postgres://todoapp@postgres/todos" --network codeshippythondjangotodoappv2_default codeshippythondjangotodoappv2_web.slim gunicorn -b 0.0.0.0:8000 todosapp.wsgi:application
 
 
 

--- a/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/slim.command
+++ b/3rdparty/codeship-python-django-todoapp-v2/_dockerslim/slim.command
@@ -3,4 +3,4 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker-slim build --http-probe-cmd /todos/ --expose 8000 --network codeship-python-django-todoapp-v2_default --env 'DATABASE_URL=postgres://todoapp@postgres/todos' --cmd 'sh -c "sleep 7 && python manage.py migrate && gunicorn -b 0.0.0.0:8000 todosapp.wsgi:application"' codeship-python-django-todoapp-v2_web
+docker-slim build --http-probe-cmd /todos/ --expose 8000 --network codeshippythondjangotodoappv2_default --env 'DATABASE_URL=postgres://todoapp@postgres/todos' --cmd 'sh -c "sleep 7 && python manage.py migrate && gunicorn -b 0.0.0.0:8000 todosapp.wsgi:application"' codeshippythondjangotodoappv2_web

--- a/3rdparty/codeship-python-django-todoapp-v2/docker-compose.yml
+++ b/3rdparty/codeship-python-django-todoapp-v2/docker-compose.yml
@@ -17,3 +17,4 @@ services:
     environment:
       POSTGRES_USER: todoapp
       POSTGRES_DB: todos
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/3rdparty/codeship-python-django-todoapp/_dockerslim/clean.command
+++ b/3rdparty/codeship-python-django-todoapp/_dockerslim/clean.command
@@ -3,7 +3,7 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here/..
 
-docker rmi codeship-python-django-todoapp_web.slim
-docker rmi codeship-python-django-todoapp_web
+docker rmi codeshippythondjangotodoapp_web.slim
+docker rmi codeshippythondjangotodoapp_web
 
 

--- a/3rdparty/codeship-python-django-todoapp/_dockerslim/docker-compose.slim.yml
+++ b/3rdparty/codeship-python-django-todoapp/_dockerslim/docker-compose.slim.yml
@@ -13,3 +13,4 @@ services:
     environment:
       POSTGRES_USER: todoapp
       POSTGRES_DB: todos
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/3rdparty/codeship-python-django-todoapp/_dockerslim/docker-compose.slim.yml
+++ b/3rdparty/codeship-python-django-todoapp/_dockerslim/docker-compose.slim.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   web:
-    image: codeship-python-django-todoapp_web.slim
+    image: codeshippythondjangotodoapp_web.slim
     depends_on:
       - postgres
     ports:

--- a/3rdparty/codeship-python-django-todoapp/_dockerslim/run_app_only_slim.command
+++ b/3rdparty/codeship-python-django-todoapp/_dockerslim/run_app_only_slim.command
@@ -3,7 +3,7 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker run -it --rm --name="django_todo_app" -p 8000:8000 -e "DATABASE_URL=postgres://todoapp@postgres/todos" --network codeship-python-django-todoapp_default codeship-python-django-todoapp_web.slim
+docker run -it --rm --name="django_todo_app" -p 8000:8000 -e "DATABASE_URL=postgres://todoapp@postgres/todos" --network codeshippythondjangotodoapp_default codeshippythondjangotodoapp_web.slim
 
 
 

--- a/3rdparty/codeship-python-django-todoapp/_dockerslim/slim.command
+++ b/3rdparty/codeship-python-django-todoapp/_dockerslim/slim.command
@@ -3,4 +3,4 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker-slim build --http-probe-cmd /todos/ --expose 8000 --network codeship-python-django-todoapp_default --env 'DATABASE_URL=postgres://todoapp@postgres/todos' codeship-python-django-todoapp_web
+docker-slim build --http-probe-cmd /todos/ --expose 8000 --network codeshippythondjangotodoapp_default --env 'DATABASE_URL=postgres://todoapp@postgres/todos' codeshippythondjangotodoapp_web

--- a/3rdparty/codeship-python-django-todoapp/docker-compose.yml
+++ b/3rdparty/codeship-python-django-todoapp/docker-compose.yml
@@ -13,3 +13,5 @@ services:
     environment:
       POSTGRES_USER: todoapp
       POSTGRES_DB: todos
+      POSTGRES_HOST_AUTH_METHOD: trust
+

--- a/3rdparty/gabimelo-flask-boilerplate/_dockerslim/clean.command
+++ b/3rdparty/gabimelo-flask-boilerplate/_dockerslim/clean.command
@@ -3,7 +3,7 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here/..
 
-docker rmi gabimelo-flask-boilerplate_app.slim
+docker rmi gabimeloflaskboilerplate_app.slim
 
 
 

--- a/3rdparty/gabimelo-flask-boilerplate/_dockerslim/docker-compose.slim.yml
+++ b/3rdparty/gabimelo-flask-boilerplate/_dockerslim/docker-compose.slim.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   app:
-    image: gabimelo-flask-boilerplate_app.slim
+    image: gabimeloflaskboilerplate_app.slim
     ports:
      - "5000:80"
 #    volumes:

--- a/3rdparty/gabimelo-flask-boilerplate/_dockerslim/run_app_only_slim.command
+++ b/3rdparty/gabimelo-flask-boilerplate/_dockerslim/run_app_only_slim.command
@@ -3,7 +3,7 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker run -it --rm --name="flask_nginx_app" -p 5000:80 --network gabimelo-flask-boilerplate_default gabimelo-flask-boilerplate_app.slim
+docker run -it --rm --name="flask_nginx_app" -p 5000:80 --network gabimeloflaskboilerplate_default gabimeloflaskboilerplate_app.slim
 
 
 

--- a/3rdparty/gabimelo-flask-boilerplate/_dockerslim/slim.command
+++ b/3rdparty/gabimelo-flask-boilerplate/_dockerslim/slim.command
@@ -3,4 +3,4 @@
 here="$(dirname "$BASH_SOURCE")"
 cd $here
 
-docker-slim build --http-probe --expose 80 --network gabimelo-flask-boilerplate_default gabimelo-flask-boilerplate_app
+docker-slim build --http-probe --expose 80 --network gabimeloflaskboilerplate_default gabimeloflaskboilerplate_app

--- a/3rdparty/gabimelo-flask-boilerplate/requirements.txt
+++ b/3rdparty/gabimelo-flask-boilerplate/requirements.txt
@@ -2,6 +2,6 @@ click==6.7
 Flask==0.12.2
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1
 pymongo==2.8
 Werkzeug==0.14.1


### PR DESCRIPTION
A few 3rdparty examples have miscellaneous bugs in image names and dependencies that prevent the sample scripts from running properly.

This PR fixes:

- Extra hyphens in the django codeship project names that prevent various commands from running
- Postgres skip auth check flags in codeship projects' docker-compose.yml files
- A MarkupSafe 1.0->1.1 issue in the gabimelo flask project.