### PR TITLE
fix: vuejs-compose npm run build step started failing

### DIFF
--- a/vuejs-compose/vuejs/Dockerfile
+++ b/vuejs-compose/vuejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bullseye as build-stage
+FROM node:16-bullseye as build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
A quick fix is by pinning the Node.js base image version. The example works fine with Node.js 16.xx but stats failing with 18.xx. A proper fix should be updating the whole example to use newer packages. Don't have time for it atm.